### PR TITLE
Guard artisan profile editing access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import ProtectedRoute from "@/components/ProtectedRoute";
 import Login from "@/pages/auth/Login";
 import Signup from "@/pages/auth/Signup";
 import ArtisanProfile from "@/pages/ArtisanProfile";
+import EditArtisanProfile from "@/pages/EditArtisanProfile";
 
 export default function App() {
   const location = useLocation();
@@ -33,6 +34,14 @@ export default function App() {
           <Route path="/signup" element={<Signup />} />
 
           <Route path="/artisan/:id" element={<ArtisanProfile />} />
+          <Route
+            path="/artisan/:id/edit"
+            element={
+              <ProtectedRoute roles={["artisan"]}>
+                <EditArtisanProfile />
+              </ProtectedRoute>
+            }
+          />
           
           {/* Protected routes */}
           <Route

--- a/src/pages/ArtisanProfile.tsx
+++ b/src/pages/ArtisanProfile.tsx
@@ -225,7 +225,7 @@ export default function ArtisanProfile() {
                     {isOwnProfile ? (
                       <Button
                         variant="outline"
-                        onClick={() => navigate("/profile/edit")}
+                        onClick={() => navigate(`/artisan/${artisan._id}/edit`)}
                       >
                         Modifier le profil
                       </Button>

--- a/src/pages/EditArtisanProfile.tsx
+++ b/src/pages/EditArtisanProfile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -11,24 +11,33 @@ import { useAuth } from "@/context/AuthContext";
 export default function EditArtisanProfile() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { user } = useAuth(); // Logged‑in artisan
+  const { user, loading: authLoading } = useAuth(); // Logged‑in artisan
 
   const [profile, setProfile] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [accessDenied, setAccessDenied] = useState(false);
+
+  const canEdit = useMemo(() => {
+    if (!user || !id) return false;
+    return user.id === id && user.role === "artisan";
+  }, [id, user]);
 
   // Redirect if trying to edit someone else's profile
   useEffect(() => {
-    if (!user) return;
-    if (user.id !== id) navigate("/not-authorized");
-  }, [user, id, navigate]);
+    if (authLoading) return;
 
-  useEffect(() => {
+    if (!canEdit) {
+      setAccessDenied(true);
+      setLoading(false);
+      return;
+    }
+
     fetchProfile();
-  }, [id]);
+  }, [authLoading, canEdit, fetchProfile]);
 
-  async function fetchProfile() {
+  const fetchProfile = useCallback(async () => {
     try {
       const res = await fetch(
         `http://localhost:3000/api/artisans/${id}/profile`
@@ -41,7 +50,7 @@ export default function EditArtisanProfile() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [id]);
 
   function handleAvatarChange(e: any) {
     const file = e.target.files[0];
@@ -101,10 +110,33 @@ export default function EditArtisanProfile() {
     }
   }
 
-  if (loading) {
+  if (loading || authLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center text-muted-foreground">
         Chargement...
+      </div>
+    );
+  }
+
+  if (accessDenied) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <Card className="max-w-lg w-full text-center border-destructive/40">
+          <CardHeader>
+            <CardTitle className="text-xl">Accès refusé</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-muted-foreground">
+            <p>Vous ne pouvez modifier que votre propre profil artisan.</p>
+            <div className="flex justify-center gap-3">
+              <Button variant="outline" onClick={() => navigate(-1)}>
+                Retour
+              </Button>
+              <Button onClick={() => navigate(`/artisan/${id}`)}>
+                Voir le profil
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- restrict the artisan edit page so only the logged-in artisan owner can load it
- add an access denied message with navigation options when another user reaches the edit path
- avoid unauthorized fetches by guarding profile loading and waiting for auth state

## Testing
- npm run lint *(fails: npm command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932247810bc8326955311cf30a446f5)