### PR TITLE
Fix avatar upload field for artisan profile updates

### DIFF
--- a/src/pages/EditArtisanProfile.tsx
+++ b/src/pages/EditArtisanProfile.tsx
@@ -81,12 +81,14 @@ export default function EditArtisanProfile() {
 
       if (profile.avatarFile) {
         const formData = new FormData();
-        formData.append("file", profile.avatarFile);
+        formData.append("image", profile.avatarFile);
 
         const uploadRes = await fetch("http://localhost:3000/api/upload", {
           method: "POST",
           body: formData,
         });
+
+        if (!uploadRes.ok) throw new Error("Upload failed");
 
         const uploadData = await uploadRes.json();
         avatarUrl = uploadData.url;
@@ -96,6 +98,7 @@ export default function EditArtisanProfile() {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          userId: user?.id,
           name: profile.name,
           bio: profile.bio,
           location: profile.location,


### PR DESCRIPTION
## Summary
- send avatar upload using the `image` field expected by the backend
- fail fast when avatar upload response is not successful before submitting the profile update

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693227a25fe483269ac8b1ff66b0564d)