### PR TITLE
Fix Cloudinary upload storage compatibility

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,11 +11,14 @@
   "description": "",
   "dependencies": {
     "bcryptjs": "^3.0.3",
+    "cloudinary": "^2.8.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^7.0.0",
+    "multer": "^2.0.2",
+    "multer-storage-cloudinary": "^2.2.1",
     "neo4j-driver": "^6.0.1"
   },
   "devDependencies": {

--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -5,13 +5,23 @@ const cloudinary = require("../utils/cloudinary");
 
 const router = express.Router();
 
-const storage = cloudinaryStorage({
-  cloudinary,
-  params: {
-    folder: "artisan_market", // Folder name in Cloudinary
-    allowed_formats: ["jpg", "png", "jpeg", "webp"], // FIXED KEY
-  },
-});
+const StorageCtor = cloudinaryStorage.CloudinaryStorage || cloudinaryStorage;
+const storage =
+  typeof StorageCtor === "function" && StorageCtor.prototype
+    ? new StorageCtor({
+        cloudinary,
+        params: {
+          folder: "artisan_market", // Folder name in Cloudinary
+          allowed_formats: ["jpg", "png", "jpeg", "webp"], // FIXED KEY
+        },
+      })
+    : cloudinaryStorage({
+        cloudinary,
+        params: {
+          folder: "artisan_market", // Folder name in Cloudinary
+          allowed_formats: ["jpg", "png", "jpeg", "webp"], // FIXED KEY
+        },
+      });
 
 const upload = multer({ storage });
 

--- a/backend/utils/cloudinary.js
+++ b/backend/utils/cloudinary.js
@@ -1,10 +1,10 @@
-const cloudinary = require("cloudinary");
+const { v2: cloudinary } = require("cloudinary");
 
-cloudinary.v2.config({
+cloudinary.config({
   cloud_name: process.env.CLOUDINARY_NAME,
   api_key: process.env.CLOUDINARY_KEY,
   api_secret: process.env.CLOUDINARY_SECRET,
-  secure: true // Force HTTPS URLs (recommended)
+  secure: true, // Force HTTPS URLs (recommended)
 });
 
 if (!process.env.CLOUDINARY_NAME || !process.env.CLOUDINARY_KEY || !process.env.CLOUDINARY_SECRET) {


### PR DESCRIPTION
## Summary
- configure and export the Cloudinary v2 client before creating storage
- make the upload route work with both factory- and class-based multer-storage-cloudinary APIs
- add missing Cloudinary and multer dependencies to the backend package manifest

## Testing
- Not run (Node and npm were unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f523bf808326b99e26df043380eb)